### PR TITLE
feat: export compile commands on build

### DIFF
--- a/platform_cli/groups/ros.py
+++ b/platform_cli/groups/ros.py
@@ -81,8 +81,10 @@ class Ros(PlatformCliGroup):
                     env = get_ros_env()
                     args_str += f" --merge-install --symlink-install --install-base /opt/greenroom/{env['PLATFORM_MODULE']}"
 
+                args_str += " --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+
                 if debug_symbols:
-                    args_str += " --cmake-args -D CMAKE_BUILD_TYPE=RelWithDebInfo"
+                    args_str += " -D CMAKE_BUILD_TYPE=RelWithDebInfo"
 
                 return call(f"colcon build {args_str}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved build configuration to automatically export compile commands and adjusted CMake build type flag formatting for better build system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->