### PR TITLE
feat: add ability to specify extra cmake args

### DIFF
--- a/platform_cli/groups/ros.py
+++ b/platform_cli/groups/ros.py
@@ -61,7 +61,11 @@ class Ros(PlatformCliGroup):
         @click.option("--no-base", is_flag=True, default=False)
         @click.option("--deps", is_flag=True, default=False)
         @click.option(
-            "-c", "--cmake-arg", type=str, multiple=True, help="Additional CMake args (e.g. -DFOO=bar)"
+            "-c",
+            "--cmake-arg",
+            type=str,
+            multiple=True,
+            help="Additional CMake args (e.g. -DFOO=bar)",
         )
         @click.option(
             "--watch", type=bool, is_flag=True, default=False, help="Should we watch for changes?"

--- a/platform_cli/groups/ros.py
+++ b/platform_cli/groups/ros.py
@@ -61,6 +61,9 @@ class Ros(PlatformCliGroup):
         @click.option("--no-base", is_flag=True, default=False)
         @click.option("--deps", is_flag=True, default=False)
         @click.option(
+            "-c", "--cmake-arg", type=str, multiple=True, help="Additional CMake args (e.g. -DFOO=bar)"
+        )
+        @click.option(
             "--watch", type=bool, is_flag=True, default=False, help="Should we watch for changes?"
         )
         @click.argument("args", nargs=-1)
@@ -69,6 +72,7 @@ class Ros(PlatformCliGroup):
             debug_symbols: bool,
             no_base: bool,
             deps: bool,
+            cmake_arg: List[str],
             watch: bool,
             args: List[str],
         ):
@@ -91,6 +95,9 @@ class Ros(PlatformCliGroup):
                     args_str += f" --merge-install --symlink-install --install-base /opt/greenroom/{env['PLATFORM_MODULE']}"
 
                 args_str += " --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+
+                for arg in cmake_arg:
+                    args_str += f" {arg}"
 
                 if debug_symbols:
                     args_str += " -D CMAKE_BUILD_TYPE=RelWithDebInfo"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `ros build` command now supports the `--cmake-arg/-c` option, enabling users to specify custom CMake arguments during the build process. Multiple arguments can be passed by repeating the option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->