### PR TITLE
feat: [sc-20634] add pass-through options for platform ros build

### DIFF
--- a/platform_cli/groups/ros.py
+++ b/platform_cli/groups/ros.py
@@ -1,5 +1,5 @@
 from glob import glob
-from typing import List
+from typing import List, Optional
 from pathlib import Path
 import click
 
@@ -68,6 +68,18 @@ class Ros(PlatformCliGroup):
             help="Additional CMake args (e.g. -DFOO=bar)",
         )
         @click.option(
+            "--parallel-workers",
+            type=int,
+            default=None,
+            help="Limit colcon's concurrent package builds (default: one per CPU core)",
+        )
+        @click.option(
+            "--make-jobs",
+            type=int,
+            default=None,
+            help="Limit per-package make parallelism via MAKEFLAGS=-jN (default: unset)",
+        )
+        @click.option(
             "--watch", type=bool, is_flag=True, default=False, help="Should we watch for changes?"
         )
         @click.argument("args", nargs=-1)
@@ -77,6 +89,8 @@ class Ros(PlatformCliGroup):
             no_base: bool,
             deps: bool,
             cmake_arg: List[str],
+            parallel_workers: Optional[int],
+            make_jobs: Optional[int],
             watch: bool,
             args: List[str],
         ):
@@ -98,6 +112,10 @@ class Ros(PlatformCliGroup):
                     env = get_ros_env()
                     args_str += f" --merge-install --symlink-install --install-base /opt/greenroom/{env['PLATFORM_MODULE']}"
 
+                if parallel_workers is not None:
+                    # Must precede --cmake-args, which consumes everything after it.
+                    args_str += f" --parallel-workers {parallel_workers}"
+
                 args_str += " --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
                 for arg in cmake_arg:
@@ -106,7 +124,8 @@ class Ros(PlatformCliGroup):
                 if debug_symbols:
                     args_str += " -D CMAKE_BUILD_TYPE=RelWithDebInfo"
 
-                return call(f"colcon build {args_str}")
+                call_env = {"MAKEFLAGS": f"-j{make_jobs}"} if make_jobs is not None else {}
+                return call(f"colcon build {args_str}", env=call_env)
 
             if watch:
                 return start_watcher(command)

--- a/platform_cli/groups/ros.py
+++ b/platform_cli/groups/ros.py
@@ -57,7 +57,7 @@ class Ros(PlatformCliGroup):
 
         @ros.command(name="build")
         @click.option("--package", type=str, multiple=True, help="The packages to build")
-        @click.option("--debug-symbols", is_flag=True, show_default=True, default=False)
+        @click.option("--debug-symbols", is_flag=True, show_default=True, default=True)
         @click.option("--no-base", is_flag=True, default=False)
         @click.option("--deps", is_flag=True, default=False)
         @click.option(

--- a/platform_cli/groups/ros.py
+++ b/platform_cli/groups/ros.py
@@ -69,13 +69,13 @@ class Ros(PlatformCliGroup):
         )
         @click.option(
             "--parallel-workers",
-            type=int,
+            type=click.IntRange(min=1),
             default=None,
             help="Limit colcon's concurrent package builds (default: one per CPU core)",
         )
         @click.option(
             "--make-jobs",
-            type=int,
+            type=click.IntRange(min=1),
             default=None,
             help="Limit per-package make parallelism via MAKEFLAGS=-jN (default: unset)",
         )


### PR DESCRIPTION
### Background
For large packages (e.g. `platform_control`), running `docker compose build --no-cache` often results in a full computer crash.

The offending step in the build process is Step 16:
`RUN source ${ROS_OVERLAY}/setup.sh && platform ros build --package=${PACKAGE_NAME}
`

Step 16 is the `colcon build` step where ~30 C++ packages compile in parallel — each `g++` process can use 2-4 GB of RAM, so on a multi-core machine the total can exceed 30+ GB and OOM-kill the build (or your whole system).

@blakecole recently tested an effective patch that limits the number of parallel workers that are allowed to be used simultaneously.  This patch slowed the build process slightly, but allowed it to finish without crashing the (fairly beefy) development laptop upon which it was run.

The key patch elements are:
1. **`MAKEFLAGS=-j2`** — caps parallel `make`/`g++` jobs per package
2. **`--parallel-workers 2`** — caps how many packages colcon builds simultaneously


### Notes:
The tested patch lives in `platform_control/Dockerfile`.
Original RUN Command:
```
RUN source ${ROS_OVERLAY}/setup.sh && platform ros build --package=${PACKAGE_NAME}
```

Patched RUN command:
```
RUN echo 'build:' > /tmp/colcon_defaults.yaml && \
  echo '  parallel-workers: 2' >> /tmp/colcon_defaults.yaml && \
  source ${ROS_OVERLAY}/setup.sh && \
  MAKEFLAGS="-j2" COLCON_DEFAULTS_FILE=/tmp/colcon_defaults.yaml platform ros build --package=${PACKAGE_NAME} && \
  rm /tmp/colcon_defaults.yaml
```

Our goal is to enable the `parallel-workers` and `make-jobs` passthroughs without creating (and subsequently deleting) the `colcon_defaults.yaml` file.

This will allow us to prevent large packages (like `platform_control`) from overwhelming computational resources using a simpler change to the relevant Dockerfile, for instance:
```
RUN source ${ROS_OVERLAY}/setup.sh && platform ros build --package=${PACKAGE_NAME} --parallel-workers=2 --make-jobs=2
```

### Summary
- Added two pass-through options on `platform ros build`: `--parallel-workers INT` and `--make-jobs INT`. Both default to None, so omitting them preserves today's full-parallelism behavior exactly.
- `--parallel-workers N` is appended to the colcon args before `--cmake-args` (since `--cmake-args` consumes everything after it).
- `--make-jobs N` is wired through `call(..., env={"MAKEFLAGS": f"-j{N}"})`, leveraging the existing `env` parameter on the `call()` helper — no helper changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--parallel-workers` flag to `ros build` command for optimised parallel build execution
  * Added `--make-jobs` flag to `ros build` command for controlling build job concurrency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->